### PR TITLE
Add static list of La Velada participants for voting system

### DIFF
--- a/src/data/participants.ts
+++ b/src/data/participants.ts
@@ -1,0 +1,16 @@
+export const laVeladaParticipants: string[] = [
+  "peereira",
+  "rivaldios",
+  "perxitaa",
+  "gaspi",
+  "abby",
+  "roro",
+  "andoni",
+  "carlos",
+  "alana",
+  "arigeli",
+  "viruzz",
+  "tomas",
+  "grefg",
+  "westcol",
+];


### PR DESCRIPTION
Define and export a static list of participants from La Velada for use in the voting system.